### PR TITLE
Add a retry wrapper to GET method for frequent 500s

### DIFF
--- a/tap_campaignmonitor/http.py
+++ b/tap_campaignmonitor/http.py
@@ -77,8 +77,8 @@ class Client(object):
 
     def retry_get(self, stream=None, campaign_id=None, page=1, date=None):
         """Wrap certain streams in a retry wrapper for frequent 500s"""
-        retries = 20
-        delay = 120
+        retries = 5
+        delay = 10
         backoff = 1.5
         attempt = 1
         while retries >= attempt:
@@ -94,7 +94,7 @@ class Client(object):
             else:
                 return response
         url = self.activity_sync_url(stream=stream, campaign_id=campaign_id,
-                                       page=page, date=date)
+                                     page=page, date=date)
         logger.error(f'Status code of latest attempt: {response.status_code}')
         logger.error(f'Latest attempt response {response.content}')
         raise ValueError(f'Failed {retries} times trying to hit endpoint {url}')

--- a/tap_campaignmonitor/streams.py
+++ b/tap_campaignmonitor/streams.py
@@ -67,7 +67,7 @@ def sync(context):
 
 def call_stream_full(context, stream):
     if stream == 'campaigns':
-        response = context.client.retry_get(stream='campaigns')
+        response = context.client.retry_get(stream=stream)
         records_to_write = json.loads(response.content)
         write_records(stream, records_to_write)
 


### PR DESCRIPTION
Added a new method retry_get that wraps an existing method to get streams (GET) into multiple retries.
Replaced GET method with retry_get in streams.py

## Testing
I've done manual testing on my laptop to ensure it works

## Risk
This is somewhat risky, but I feel confident